### PR TITLE
add --privkey flag to not use multiple enodes

### DIFF
--- a/cmd/x-check-mailserver/config.go
+++ b/cmd/x-check-mailserver/config.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/status-im/status-go/params"
 )
 
-func newNodeConfig(fleet string, networkID uint64) (*params.NodeConfig, error) {
+func newNodeConfig(fleet string, networkID uint64, privKey string) (*params.NodeConfig, error) {
 	c, err := params.NewNodeConfig("", networkID)
 	if err != nil {
 		return nil, err
@@ -12,6 +15,13 @@ func newNodeConfig(fleet string, networkID uint64) (*params.NodeConfig, error) {
 
 	if err := params.WithFleet(fleet)(c); err != nil {
 		return nil, err
+	}
+
+	cleanPrivKey := strings.TrimPrefix(privKey, "0x")
+	if len(cleanPrivKey) == 64 {
+		c.NodeKey = cleanPrivKey
+	} else if len(cleanPrivKey) != 64 && len(cleanPrivKey) != 0 {
+		return nil, errors.New("wrong private key length, expected 64 char hexadecimal")
 	}
 
 	c.ListenAddr = ":0"

--- a/cmd/x-check-mailserver/flags.go
+++ b/cmd/x-check-mailserver/flags.go
@@ -10,6 +10,7 @@ import (
 var (
 	fleet       = pflag.StringP("fleet", "f", params.FleetProd, "cluster fleet")
 	datadir     = pflag.StringP("datadir", "d", "/tmp", "home directory for node data")
+	privkey     = pflag.StringP("privkey", "p", "", "private key for connecting to nodes, hexadecimal")
 	mailservers = pflag.StringArrayP("mailservers", "m", nil, "a list of mail servers")
 	duration    = pflag.DurationP("duration", "l", time.Hour*24, "length of time span from now")
 	channels    = pflag.StringArrayP("channels", "c", []string{"status"}, "name of one or more channels")

--- a/cmd/x-check-mailserver/main.go
+++ b/cmd/x-check-mailserver/main.go
@@ -34,7 +34,7 @@ func main() {
 	}()
 
 	// create config
-	config, err := newNodeConfig(*fleet, params.MainNetworkID)
+	config, err := newNodeConfig(*fleet, params.MainNetworkID, *privkey)
 	if err != nil {
 		log.Crit("failed to create a config", "err", err)
 	}
@@ -76,7 +76,7 @@ func main() {
 		nodeConfig := *config
 		log.Debug("using node config", "config", nodeConfig)
 
-		work := NewWorkUnit(msEnode, &nodeConfig)
+		work := NewWorkUnit(msEnode, &nodeConfig, *privkey)
 		go func(work *WorkUnit) {
 			if err := work.Execute(workConfig); err != nil {
 				log.Crit("failed to execute work", "err", err, "enode", work.MailServerEnode)


### PR DESCRIPTION
In order to reduce noise in our retention metrics I'm adding a `--privkey` flag in order to use only on identity when checking servers.

I tested it an it seems to work fine:
```
 > ./bin/x-check-mailserver -v warn -p 0x19e8fa020a8fe1c5664eab9f2a8a45119b5b545a6c9d6cdfea623ba8741a97b2
{"level":"info","ts":1595504174.5687137,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5689538,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5690098,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5690262,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5694127,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5695589,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
{"level":"info","ts":1595504174.5699446,"caller":"publisher/publisher.go:47","msg":"starting publisher","Publisher":{"site":"Start"}}
```
But just in case I'd like to ask @cammellos to weigh in if this might cause any issues.